### PR TITLE
Recalculation Overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "karl",
-  "version": "1.4.2",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -128,6 +128,7 @@
 				specialCaseDoubleBarrel = true;
 			}
 		}
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
 
 		let timeToEmpty = dpsStats.magazineSize / dpsStats.rateOfFire;
 		let damageTime = timeToEmpty + dpsStats.reloadTime;
@@ -146,7 +147,7 @@
 			dps: parseFloat(damagePerSecond).toFixed(2),
 			dpb: dpsStats.damage,
 			dpm: magazineDamage,
-			dpa: dpsStats.damage * (dpsStats.maxAmmo + dpsStats.magazineSize)
+			dpa: dpsStats.damage * (dpsStats.maxAmmo)
 		};
 	};
 

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -94,7 +94,6 @@
 <!--todo: show most cost effective upgrade in tier (most change %)-->
 <script>
 	import store from "../store";
-
 	const _calculateDamage = stats => {
 		let damageWords = ["Damage", "Area Damage", "Electric Damage", "Direct Damage"];
 		let magazineSizeWords = ["Tank Size", "Magazine Size", "Clip Size", "Combined Clip Size"];
@@ -147,7 +146,7 @@
 			dps: parseFloat(damagePerSecond).toFixed(2),
 			dpb: dpsStats.damage,
 			dpm: magazineDamage,
-			dpa: dpsStats.damage * dpsStats.maxAmmo
+			dpa: dpsStats.damage * (dpsStats.maxAmmo + dpsStats.magazineSize)
 		};
 	};
 

--- a/src/components/StatsDisplay.vue
+++ b/src/components/StatsDisplay.vue
@@ -123,10 +123,6 @@
 				dpsStats.maxAmmo = parseFloat(stat.value);
 			}
 
-			// temporary special case for double barrel oc
-			if (stat.name === "Double Barrel" && stat.value === "1") {
-				specialCaseDoubleBarrel = true;
-			}
 		}
 		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
 
@@ -134,18 +130,9 @@
 		let damageTime = timeToEmpty + dpsStats.reloadTime;
 		let magazineDamage = dpsStats.damage * dpsStats.magazineSize;
 		let damagePerSecond = magazineDamage / damageTime;
-		// todo: move boomstick calculation out of here to remove last special case
-		if (specialCaseDoubleBarrel) {
-			return {
-				dps: parseFloat(damagePerSecond * 2).toFixed(2),
-				dpb: dpsStats.damage * 2,
-				dpm: magazineDamage,
-				dpa: dpsStats.damage * dpsStats.maxAmmo
-			};
-		}
+
 		return {
 			dps: parseFloat(damagePerSecond).toFixed(2),
-			dpb: dpsStats.damage,
 			dpm: magazineDamage,
 			dpa: dpsStats.damage * (dpsStats.maxAmmo)
 		};

--- a/src/equipment/D_E_Drill.js
+++ b/src/equipment/D_E_Drill.js
@@ -4,6 +4,24 @@ export default {
 	name: "Reinforced power drills",
 	class: "support tool",
 	icon: "equipment.D_E_Drill",
+	calculateDamage: (stats) => {
+		for (let stat of stats) {
+			if (stat.name === "Damage") {
+				dpsStats.damage = parseFloat(stat.value);
+			} else if (stat.name === "Mining Rate") {
+				dpsStats.miningRate = parseFloat(stat.value);
+			}
+		}
+		rof = (dpsStats.miningRate / 100) * 2
+
+		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
+
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo / 2).toFixed(0);
+
+		return {
+			dps: damagePerSecond, // damage per second
+		};
+	},
 	baseStats: {
 		dmg: { name: "Damage", value: 5 },
 		ammo: { name: "Max Fuel", value: 38 },

--- a/src/equipment/D_E_Drill.js
+++ b/src/equipment/D_E_Drill.js
@@ -16,8 +16,6 @@ export default {
 
 		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
 
-		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo / 2).toFixed(0);
-
 		return {
 			dps: damagePerSecond, // damage per second
 		};

--- a/src/equipment/D_E_Drill.js
+++ b/src/equipment/D_E_Drill.js
@@ -5,25 +5,34 @@ export default {
 	class: "support tool",
 	icon: "equipment.D_E_Drill",
 	calculateDamage: (stats) => {
+		let damagePerSecond;
+		let totalDamage
+		let rof;
+		let dpsStats = {};
 		for (let stat of stats) {
 			if (stat.name === "Damage") {
 				dpsStats.damage = parseFloat(stat.value);
 			} else if (stat.name === "Mining Rate") {
 				dpsStats.miningRate = parseFloat(stat.value);
+			} else if (stat.name === "Max Fuel") {
+				dpsStats.maxFuel = parseFloat(stat.value);
 			}
 		}
 		rof = (dpsStats.miningRate / 100) * 2
 
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxFuel).toFixed(0);
+
 		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
 
 		return {
+			dpa: totalDamage, // total damage available
 			dps: damagePerSecond, // damage per second
 		};
 	},
 	baseStats: {
 		dmg: { name: "Damage", value: 5 },
 		ammo: { name: "Max Fuel", value: 38 },
-		rate: { name: "Mining rate", value: 100, percent: true },
+		rate: { name: "Mining Rate", value: 100, percent: true },
 		ex1: { name: "Overheat Duration", value: 8 },
 		ex2: { name: "Cooling Rate", value: 2 },
 		ex3: { name: "Movement speed while drilling", value: 0, percent: true },

--- a/src/equipment/D_P1_CRSPR.js
+++ b/src/equipment/D_P1_CRSPR.js
@@ -5,20 +5,29 @@ export default {
 	class: "Heavy Weapon",
 	icon: "equipment.D_P1_CRSPR",
 	calculateDamage: (stats) => {
+		let damagePerSecond;
+		let totalDamage;
+		let rof;
+		let dpsStats = {};
 		for (let stat of stats) {
 			if (stat.name === "Damage") {
 				dpsStats.damage = parseFloat(stat.value);
-			} else if (stat.name === "Flow Rate") {
+			} else if (stat.name === "Fuel Flow Rate") {
 				dpsStats.flowRate = parseFloat(stat.value);
-			} else if (stat.name === "Max Ammo") {
-				dpsStats.maxAmmo = parseFloat(stat.value);
+			} else if (stat.name === "Max Fuel") {
+				dpsStats.maxFuel = parseFloat(stat.value);
+			} else if (stat.name === "Tank Size") {
+				dpsStats.tankSize = parseFloat(stat.value);
 			}
 		}
+
+		dpsStats.maxFuel = dpsStats.maxFuel + dpsStats.tankSize;
+
 		rof = (dpsStats.flowRate / 100) * 6
 
 		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
 
-		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo / 2).toFixed(0);
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxFuel).toFixed(0);
 
 		return {
 			dps: damagePerSecond, // damage per second

--- a/src/equipment/D_P1_CRSPR.js
+++ b/src/equipment/D_P1_CRSPR.js
@@ -24,6 +24,7 @@ export default {
 			dps: damagePerSecond, // damage per second
 			dpa: totalDamage // total damage available
 		};
+	},
 	baseStats: {
 		dmg: { name: "Damage", value: 10 },
 		ex11: { name: "Heat", value: 10 },

--- a/src/equipment/D_P1_CRSPR.js
+++ b/src/equipment/D_P1_CRSPR.js
@@ -4,6 +4,26 @@ export default {
 	name: "CRSPR Flamethrower",
 	class: "Heavy Weapon",
 	icon: "equipment.D_P1_CRSPR",
+	calculateDamage: (stats) => {
+		for (let stat of stats) {
+			if (stat.name === "Damage") {
+				dpsStats.damage = parseFloat(stat.value);
+			} else if (stat.name === "Flow Rate") {
+				dpsStats.flowRate = parseFloat(stat.value);
+			} else if (stat.name === "Max Ammo") {
+				dpsStats.maxAmmo = parseFloat(stat.value);
+			}
+		}
+		rof = (dpsStats.flowRate / 100) * 6
+
+		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
+
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo / 2).toFixed(0);
+
+		return {
+			dps: damagePerSecond, // damage per second
+			dpa: totalDamage // total damage available
+		};
 	baseStats: {
 		dmg: { name: "Damage", value: 10 },
 		ex11: { name: "Heat", value: 10 },

--- a/src/equipment/D_P2_Cryo.js
+++ b/src/equipment/D_P2_Cryo.js
@@ -5,21 +5,25 @@ export default {
 	class: "Heavy Weapon",
 	icon: "equipment.D_P2_Cryo",
 	calculateDamage: (stats) => {
-		// todo: dps from damage and flow rate (take 10 shots/s for 100% flow rate?)
+		let damagePerSecond;
+		let totalDamage;
+		let rof;
+		let dpsStats = {};
 		for (let stat of stats) {
 			if (stat.name === "Damage") {
 				dpsStats.damage = parseFloat(stat.value);
 			} else if (stat.name === "Flow Rate") {
 				dpsStats.flowRate = parseFloat(stat.value);
-			} else if (stat.name === "Max Ammo") {
-				dpsStats.maxAmmo = parseFloat(stat.value);
+			} else if (stat.name === "Tank Capacity") {
+				dpsStats.tankCapacity = parseFloat(stat.value);
 			}
 		}
+
 		rof = (dpsStats.flowRate / 100) * 8
 
 		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
 
-		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo / 2).toFixed(0);
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.tankCapacity).toFixed(0);
 
 		return {
 			dps: damagePerSecond, // damage per second

--- a/src/equipment/D_P2_Cryo.js
+++ b/src/equipment/D_P2_Cryo.js
@@ -6,7 +6,25 @@ export default {
 	icon: "equipment.D_P2_Cryo",
 	calculateDamage: (stats) => {
 		// todo: dps from damage and flow rate (take 10 shots/s for 100% flow rate?)
-		return {};
+		for (let stat of stats) {
+			if (stat.name === "Damage") {
+				dpsStats.damage = parseFloat(stat.value);
+			} else if (stat.name === "Flow Rate") {
+				dpsStats.flowRate = parseFloat(stat.value);
+			} else if (stat.name === "Max Ammo") {
+				dpsStats.maxAmmo = parseFloat(stat.value);
+			}
+		}
+		rof = (dpsStats.flowRate / 100) * 8
+
+		damagePerSecond = parseFloat(dpsStats.damage * rof).toFixed(2);
+
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo / 2).toFixed(0);
+
+		return {
+			dps: damagePerSecond, // damage per second
+			dpa: totalDamage // total damage available
+		};
 	},
 	baseStats: {
 		dmg: { name: "Damage", value: 6 },

--- a/src/equipment/E_E_Sentry.js
+++ b/src/equipment/E_E_Sentry.js
@@ -4,13 +4,31 @@ export default {
 	name: "LMG Gun Platform",
 	class: "Sentry Gun",
 	icon: "equipment.E_E_Sentry",
+	calculateDamage: (stats) => {
+		for (let stat of stats) {
+			if (stat.name === "Damage") {
+				dpsStats.damage = parseFloat(stat.value);
+			} else if (stat.name === "Rate of Fire") {
+				dpsStats.rateOfFire = parseFloat(stat.value);
+			}
+		}
+
+		damagePerSecond = parseFloat(dpsStats.damage * dpsStats.rateOfFire).toFixed(2);
+
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo).toFixed(0);
+
+		return {
+			dps: damagePerSecond, // damage per second
+			dpa: totalDamage, //total damage available
+		};
+	},
 	baseStats: {
 		ammo: { name: "Carried Amount", value: 425 },
 		rate: { name: "Construction Time", value: 4 },
 		clip: { name: "Sentry Ammo Capacity", value: 90 },
 		reload: { name: "Reload Ammo Per Second", value: 45 },
 		dmg: { name: "Damage", value: 5 },
-		dmg2: { name: "Damage Bonus", value: 0, percent: true },
+		rof: { name: "Rate of Fire", value: 7.5 },
 		range: { name: "Max Targeting Range", value: 20 },
 		amount: { name: "Number of Sentries", value: 1 },
 		ex1: { name: "Armor Breaking", value: 100, percent: true },
@@ -196,7 +214,7 @@ export default {
 				type: "Special",
 				text: "A design variation with greatly increased shot power and a focused scan angle.",
 				stats: {
-					dmg2: { name: "Damage Bonus", value: 100, percent: true },
+					dmg: { name: "Damage", value: 2, multiply: true },
 					ex3: { name: "Defender System", value: 1, boolean: true }
 				},
 				cost: {

--- a/src/equipment/E_E_Sentry.js
+++ b/src/equipment/E_E_Sentry.js
@@ -5,17 +5,26 @@ export default {
 	class: "Sentry Gun",
 	icon: "equipment.E_E_Sentry",
 	calculateDamage: (stats) => {
+		let damagePerSecond;
+		let totalDamage;
+		let dpsStats = {};
 		for (let stat of stats) {
 			if (stat.name === "Damage") {
 				dpsStats.damage = parseFloat(stat.value);
 			} else if (stat.name === "Rate of Fire") {
 				dpsStats.rateOfFire = parseFloat(stat.value);
+			} else if (stat.name === "Carried Amount") {
+				dpsStats.carriedAmount = parseFloat(stat.value);
+			} else if (stat.name === "Sentry Ammo Capacity") {
+				dpsStats.sentryAmmoCapacity = parseFloat(stat.value);
 			}
 		}
 
+		dpsStats.carriedAmount = dpsStats.carriedAmount + dpsStats.sentryAmmoCapacity;
+
 		damagePerSecond = parseFloat(dpsStats.damage * dpsStats.rateOfFire).toFixed(2);
 
-		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo).toFixed(0);
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.carriedAmount).toFixed(0);
 
 		return {
 			dps: damagePerSecond, // damage per second

--- a/src/equipment/E_P1_Warthog.js
+++ b/src/equipment/E_P1_Warthog.js
@@ -4,6 +4,46 @@ export default {
 	name: "\"Warthog\" Auto 210",
 	class: "Shotgun",
 	icon: "equipment.E_P1_Warthog",
+	calculateDamage: (stats) => {
+		let damagePerSecond;
+		let damagePerBullet;
+		let totalDamage;
+		let magazineDamage;
+		let dpsStats = {};
+		// todo: minigun should include spinup time in dps, aswell as cooling rate! -> spinup time + how much damage can be done until overheated.
+		for (let stat of stats) {
+			if (stat.name === "Damage") {
+				dpsStats.damage = parseFloat(stat.value);
+			} else if (stat.name === "Rate of Fire") {
+				dpsStats.rateOfFire = parseFloat(stat.value);
+			} else if (stat.name === "Reload Time") {
+				dpsStats.reloadTime = parseFloat(stat.value);
+			} else if (stat.name === "Max Ammo") {
+				dpsStats.maxAmmo = parseFloat(stat.value);
+			} else if (stat.name === "Magazine Size") {
+				dpsStats.magazineSize = parseFloat(stat.value);
+			} else if (stat.name === "Pellets") {
+				dpsStats.pellets = parseFloat(stat.value);
+			}
+		}
+
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
+
+		damagePerSecond = parseFloat(dpsStats.damage * dpsStats.rateOfFire).toFixed(2);
+
+		damagePerBullet = parseFloat(dpsStats.damage).toFixed(0);
+
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo).toFixed(0);
+
+		magazineDamage = dpsStats.damage * dpsStats.magazineSize;
+		
+		return {
+			dps: parseFloat(damagePerSecond).toFixed(2),
+			dpb: dpsStats.damage * dpsStats.pellets,
+			dpm: magazineDamage,
+			dpa: dpsStats.damage * dpsStats.maxAmmo
+		};
+},
 	baseStats: {
 		dmg: { name: "Damage", value: 7 },
 		ammo: { name: "Max Ammo", value: 90 },

--- a/src/equipment/G_P2_Thunder.js
+++ b/src/equipment/G_P2_Thunder.js
@@ -33,6 +33,10 @@ export default {
 				dpsStats.maxAmmo = parseFloat(stat.value);
 			}
 		}
+
+		
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
+		
 		dpsStats.damage = dpsStats.directDamage + dpsStats.areaDamage;
 
 		let timeToEmpty = dpsStats.magazineSize / dpsStats.rateOfFire;

--- a/src/equipment/G_S2_Burst.js
+++ b/src/equipment/G_S2_Burst.js
@@ -30,6 +30,9 @@ export default {
 			}
 		}
 		// damage over one burst (3 or 6 bullets used)
+
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
+
 		burstDamage = dpsStats.damage * dpsStats.burstSize;
 		if (dpsStats.burstBonus) {
 			burstDamage += dpsStats.burstBonus;

--- a/src/equipment/S_E_Flare.js
+++ b/src/equipment/S_E_Flare.js
@@ -18,7 +18,7 @@ export default {
 		}
 		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
 
-		let lightingSeconds = (dpsStats.magazineSize) * dpsStats.duration;
+		let lightingSeconds = (dpsStats.maxAmmo) * dpsStats.duration;
 		lightingMinutes = lightingSeconds / 60;
 		return {
 			ex1: lightingMinutes

--- a/src/equipment/S_E_Flare.js
+++ b/src/equipment/S_E_Flare.js
@@ -16,13 +16,16 @@ export default {
 				dpsStats.maxAmmo = parseFloat(stat.value);
 			}
 		}
-		let lightingSeconds = (dpsStats.magazineSize + dpsStats.maxAmmo) * dpsStats.duration;
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
+
+		let lightingSeconds = (dpsStats.magazineSize) * dpsStats.duration;
 		lightingMinutes = lightingSeconds / 60;
 		return {
 			ex1: lightingMinutes
 		};
 	},
 	baseStats: {
+		dmg: { name: "Damage", value: 40 },
 		duration: { name: "Duration", value: 75 },
 		clip: { name: "Magazine Size", value: 3 },
 		ammo: { name: "Max Ammo", value: 12 },

--- a/src/equipment/S_S1_Jury.js
+++ b/src/equipment/S_S1_Jury.js
@@ -4,6 +4,57 @@ export default {
 	name: "Jury-Rigged Boomstick",
 	class: "Shotgun",
 	icon: "equipment.S_S1_Jury",
+	calculateDamage: (stats) => {
+		let damagePerSecond;
+		let damagePerBullet;
+		let totalDamage;
+		let magazineDamage;
+		let dpsStats = {};
+		// todo: minigun should include spinup time in dps, aswell as cooling rate! -> spinup time + how much damage can be done until overheated.
+		for (let stat of stats) {
+			if (stat.name === "Damage") {
+				dpsStats.damage = parseFloat(stat.value);
+			} else if (stat.name === "Rate of Fire") {
+				dpsStats.rateOfFire = parseFloat(stat.value);
+			} else if (stat.name === "Reload Time") {
+				dpsStats.reloadTime = parseFloat(stat.value);
+			} else if (stat.name === "Max Ammo") {
+				dpsStats.maxAmmo = parseFloat(stat.value);
+			} else if (stat.name === "Double Barrel" && stat.value === "1") {
+				dpsStats.doubleBarrel = true
+			}else if (stat.name === "Magazine Size") {
+				dpsStats.magazineSize = parseFloat(stat.value);
+			} else if (stat.name === "Pellets") {
+				dpsStats.pellets = parseFloat(stat.value);
+			}
+		}
+
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
+
+		damagePerSecond = parseFloat(dpsStats.damage * dpsStats.rateOfFire).toFixed(2);
+
+		damagePerBullet = parseFloat(dpsStats.damage * dpsStats.pellets).toFixed(0);
+
+		totalDamage = parseFloat(dpsStats.damage * dpsStats.maxAmmo).toFixed(0);
+
+		magazineDamage = dpsStats.damage * dpsStats.magazineSize;
+
+		if (dpsStats.doubleBarrel) {
+			return {
+				dps: parseFloat(damagePerSecond * 2).toFixed(2),
+				dpb: damagePerBullet * 2,
+				dpm: magazineDamage,
+				dpa: dpsStats.damage * dpsStats.maxAmmo
+			};
+		} else {
+		return {
+			dps: parseFloat(damagePerSecond).toFixed(2),
+			dpb: damagePerBullet,
+			dpm: magazineDamage,
+			dpa: dpsStats.damage * dpsStats.maxAmmo
+		};
+	}
+	},
 	baseStats: {
 		dmg: { name: "Damage", value: 12 },
 		ammo: { name: "Max Ammo", value: 24 },

--- a/src/equipment/S_S2_Zhuk.js
+++ b/src/equipment/S_S2_Zhuk.js
@@ -24,6 +24,8 @@ export default {
 			}
 		}
 
+		dpsStats.maxAmmo = dpsStats.maxAmmo + dpsStats.magazineSize;
+
 		let timeToEmpty = dpsStats.magazineSize / dpsStats.rateOfFire;
 		let damageTime = timeToEmpty + dpsStats.reloadTime;
 


### PR DESCRIPTION
Added dps counters for all weapons/utility that did not previously have one (excluding the flare gun and breach cutter), removed redundant "damage per shot" stat on non shotguns,  fixed "total damage" not accounting for bullets in the magazine.